### PR TITLE
Add volunteer actions

### DIFF
--- a/.github/workflows/volunteers.yml
+++ b/.github/workflows/volunteers.yml
@@ -1,0 +1,11 @@
+name: "Issue volunteer assignment"
+
+on: [issue_comment]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: bhermann/issue-volunteer@v0.1.12
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
> If someone comments on an issue without an assignee with a comment including the phrase `I would like to work on this please!`, this issue will be assigned to the person making that comment.
> If the issue already has assignees, the comment is ignored and an additional comment is added to inform the volunteer.

This actions from https://github.com/marketplace/actions/issue-volunteer-assignment